### PR TITLE
fix: make deepin-turbo a proper shared library

### DIFF
--- a/src/booster-dtkwidget/CMakeLists.txt
+++ b/src/booster-dtkwidget/CMakeLists.txt
@@ -23,18 +23,15 @@ SET(CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/src/launcherlib)
 find_package(Qt5Widgets CONFIG REQUIRED)
 
 set(LINK_LIBS
+    deepin-turbo
     Qt5::Widgets
     )
 
 # Set sources
 set(SRC booster-dtkwidget.cpp)
 
-# Set libraries to be linked.
-link_libraries("-L../launcherlib -ldeepin-turbo")
-
 # Set executable
 add_executable(booster-dtkwidget ${SRC} ${MOC_SRC})
-add_dependencies(booster-dtkwidget deepin-turbo)
 
 target_link_libraries(booster-dtkwidget
     ${LINK_LIBS}

--- a/src/launcherlib/CMakeLists.txt
+++ b/src/launcherlib/CMakeLists.txt
@@ -17,7 +17,7 @@ set(HEADERS appdata.h booster.h connection.h daemon.h logger.h launcherlib.h
 link_libraries(${LIBDL} "-L/lib -lsystemd")
 
 # Set executable
-add_library(deepin-turbo MODULE ${SRC} ${MOC_SRC})
+add_library(deepin-turbo SHARED ${SRC} ${MOC_SRC})
 set_target_properties(deepin-turbo PROPERTIES VERSION 0.1 SOVERSION 0)
 
 if (NOT CMAKE_INSTALL_LIBDIR)


### PR DESCRIPTION
The original approach defined deepin-turbo as a MODULE target but then
try to link it explicitly. I don't really understand what happened here
but it looks wrong.

Redefine it as a SHARED target allows linking to it with a proper
target_link_libraries without having to specify paths and dependencies
manually, which actually fails when using cmake -GNinja.