### PR TITLE
chore: clean up debian/control dependencies

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -6,17 +6,13 @@ pkgdesc='A daemon that helps to launch applications faster'
 arch=('x86_64' 'aarch64')
 url="https://github.com/linuxdeepin/deepin-turbo"
 license=('GPL3')
-depends=('qt5-base')
+depends=('qt5-base' 'dtkwidget' 'dtkgui' 'dtkdeclarative')
 makedepends=('cmake' 'git')
 groups=('deepin')
 provides=('deepin-turbo')
 conflicts=('deepin-turbo')
 source=('source.tar.gz')
 sha512sums=('SKIP')
-pkgver() {
-    cd $pkgbase
-    git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
-}
 
 prepare() {
     cd $deepin_source_name

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-deepin-turbo (1.0-1) unstable; urgency=medium
+deepin-turbo (0.0.6.2) unstable; urgency=medium
 
-  * Initial release. 
+  * update
 
- -- Packages <zs@deepin.com>  Thu, 30 Aug 2018 15:36:22 +0800
+ -- Deepin Packages Builder <packages@deepin.com>  Wed, 20 Oct 2021 14:53:37 +0800

--- a/debian/control
+++ b/debian/control
@@ -5,15 +5,14 @@ Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends: debhelper (>= 9.0.0),
                cmake,
                pkg-config,
-               python,
+               python3,
                libdbus-1-dev,
                dbus,
                libsystemd-dev,
                qtbase5-dev,
-               libdtkwidget5.5-dev,
+               libdtkwidget-dev,
                qtdeclarative5-dev,
-               libdtkdeclarative-dev,
-               dh-systemd
+               libdtkdeclarative-dev
 Standards-Version: 3.9.5
 
 Package: deepin-turbo

--- a/src/booster-dtkwidget/CMakeLists.txt
+++ b/src/booster-dtkwidget/CMakeLists.txt
@@ -21,14 +21,14 @@ SET(CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/src/launcherlib)
 
 # Find the QtWidgets library
 find_package(Qt5Widgets CONFIG REQUIRED)
-find_package(DtkWidget5.5 CONFIG REQUIRED)
-find_package(DtkGui5.5 CONFIG REQUIRED)
+find_package(DtkWidget CONFIG REQUIRED)
+find_package(DtkGui CONFIG REQUIRED)
 
 set(LINK_LIBS
     deepin-turbo
     Qt5::Widgets
-    ${DtkWidget5.5_LIBRARIES}
-    ${DtkGui5.5_LIBRARIES}
+    ${DtkWidget_LIBRARIES}
+    ${DtkGui_LIBRARIES}
     )
 
 # Set sources


### PR DESCRIPTION
清理 debian/control 所声明的依赖：

1. 移除 [dh-systemd](https://packages.debian.org/sid/dh-systemd) 依赖

   > ### debhelper add-on to handle systemd unit files - transitional package
   > This package is for transitional purposes and can be removed safely.

2. 恰当声明对 dtk 的依赖
3. 使用 python3

是处理 https://github.com/linuxdeepin/developer-center/issues/3230 问题的一部分。